### PR TITLE
Basic auth

### DIFF
--- a/lib/pact/consumer_contract/pact_file.rb
+++ b/lib/pact/consumer_contract/pact_file.rb
@@ -5,7 +5,7 @@ module Pact
     extend self
 
     def read uri, options = {}
-      open_options = options[:username] ? {} : {http_basic_authentication:[options[:username],options[:password]]}
+      open_options = options[:username] ? {http_basic_authentication:[options[:username],options[:password]]} : {}
       pact = open(uri.to_s, open_options) { | file | file.read }
       if options[:save_pactfile_to_tmp]
         save_pactfile_to_tmp pact, ::File.basename(uri.to_s)

--- a/lib/pact/consumer_contract/pact_file.rb
+++ b/lib/pact/consumer_contract/pact_file.rb
@@ -5,7 +5,8 @@ module Pact
     extend self
 
     def read uri, options = {}
-      pact = open(uri.to_s) { | file | file.read }
+      open_options = options[:username] ? {} : {http_basic_authentication:[options[:username],options[:password]]}
+      pact = open(uri.to_s, open_options) { | file | file.read }
       if options[:save_pactfile_to_tmp]
         save_pactfile_to_tmp pact, ::File.basename(uri.to_s)
       end

--- a/spec/lib/pact/consumer_contract/pact_file_spec.rb
+++ b/spec/lib/pact/consumer_contract/pact_file_spec.rb
@@ -1,0 +1,47 @@
+require 'spec_helper'
+require 'pact/consumer_contract/pact_file'
+
+module Pact
+  describe PactFile do
+    describe 'render_pact' do
+      let(:uri_without_userinfo) { 'http://pactbroker.com'}
+      let(:pact_content) { 'api contract'}
+      context 'without basic authentication' do
+        it 'should open uri to get pact file content' do
+          expect(PactFile).to receive(:open).with(uri_without_userinfo, {}).and_return(pact_content)
+          expect(PactFile.render_pact(uri_without_userinfo, {})).to eq(pact_content)
+        end
+      end
+
+      context 'basic authentication' do
+        let(:username) { 'brokeruser'}
+        let(:password) { 'brokerpassword'}
+        let(:options) do
+          { username: username, password: password }
+        end
+        context 'when userinfo is specified in the option' do
+          it 'should open uri to get pact file content with userinfo in the options' do
+            expect(PactFile).to receive(:open).with(uri_without_userinfo, {http_basic_authentication:[username, password]})
+                                .and_return(pact_content)
+            expect(PactFile.render_pact(uri_without_userinfo, options)).to eq(pact_content)
+          end
+          let(:uri_with_userinfo) { 'http://dummyuser:dummyps@pactbroker.com'}
+          it 'should use userinfo in options which overwrites userinfo in url' do
+            expect(PactFile).to receive(:open).with(uri_without_userinfo, {http_basic_authentication:[username, password]})
+                                .and_return(pact_content)
+            expect(PactFile.render_pact(uri_with_userinfo, options)).to eq(pact_content)
+          end
+        end
+
+        context 'when user info is specified in url' do
+          let(:uri_with_userinfo) { "http://#{username}:#{password}@pactbroker.com"}
+          it 'should open uri to get pact file content with userinfo in the uri' do
+            expect(PactFile).to receive(:open).with(uri_without_userinfo, {http_basic_authentication:[username, password]})
+                                .and_return(pact_content)
+            expect(PactFile.render_pact(uri_with_userinfo, {})).to eq(pact_content)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Hi,

I've forked the pact, pact-support and pact_broker-client repository and made the changes on the 'basic_auth' branch for each project and created pull request.

The main changes are:

#### pact-support
pass the basic auth option to PactFile open method

#### pact
* added the basic auth options in dsl 
```ruby
honours_pact_with 'ServiceConsumer' do
    pact_uri 'http://pact-broker-url/consumer/ServiceConsumer/latest', {username: 'user', password: 'pass'}
end
```
* when running pact:verify:at['pact_broker_url'] task, currently I just let users to set environment variables PACT_REPO_USERNAME, PACT_REPO_PASSWORD for the basic auth information.  I am not sure whether it's good enough.

#### pact_broker_client
 pass optional pact_broker_basic_auth in the PublicationTask

```ruby
task.pact_broker_basic_auth =  { username: 'basic_auth_user', password: 'basic_auth_pass'} #optional 
```

#### Testing
* I've added unit tests for my changes.  The rake tasks of all the three projects all passed. 
* I used my version to run pact:verify, pact:verify:at['pact_url'] and publication task pointing to our pact broker with basic authentication and without basic authentication.  They both worked. 

#### Documentation:
I've updated the README.md file in the pact_broker-client project.  But for the pact:verify part, I am not sure where to put the examples.  


I am not sure whether my change matches your code convention. Please review my changes and I will revise based on your feedback.  Thanks.
