### PR TITLE
Use require over require_relative to avoid double-loading

### DIFF
--- a/lib/pact/consumer_contract/consumer_contract.rb
+++ b/lib/pact/consumer_contract/consumer_contract.rb
@@ -6,10 +6,10 @@ require 'pact/shared/active_support_support'
 require 'date'
 require 'json/add/regexp'
 require 'open-uri'
-require_relative 'service_consumer'
-require_relative 'service_provider'
-require_relative 'interaction'
-require_relative 'pact_file'
+require 'pact/consumer_contract/service_consumer'
+require 'pact/consumer_contract/service_provider'
+require 'pact/consumer_contract/interaction'
+require 'pact/consumer_contract/pact_file'
 
 module Pact
 

--- a/lib/pact/consumer_contract/query.rb
+++ b/lib/pact/consumer_contract/query.rb
@@ -1,5 +1,5 @@
-require_relative 'query_hash'
-require_relative 'query_string'
+require 'pact/consumer_contract/query_hash'
+require 'pact/consumer_contract/query_string'
 
 module Pact
   class Query

--- a/lib/pact/logging.rb
+++ b/lib/pact/logging.rb
@@ -1,5 +1,5 @@
 require 'logger'
-require_relative 'configuration'
+require 'pact/configuration'
 
 module Pact
   module Logging

--- a/lib/pact/matchers.rb
+++ b/lib/pact/matchers.rb
@@ -1,1 +1,1 @@
-require_relative 'matchers/matchers'
+require 'pact/matchers/matchers'


### PR DESCRIPTION

Was seeing the following warnings using rbenv. Seems require_relative and require don't agree on paths of already loaded files.

```
/usr/local/Cellar/rbenv/0.4.0/versions/2.1.2/lib/ruby/gems/2.1.0/gems/pact-support-0.4.0/lib/pact/matchers/matchers.rb:19: warning: already initialized constant Pact::Matchers::NO_DIFF_AT_INDEX
/usr/local/opt/rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/pact-support-0.4.0/lib/pact/matchers/matchers.rb:19: warning: previous definition of NO_DIFF_AT_INDEX was here
/usr/local/Cellar/rbenv/0.4.0/versions/2.1.2/lib/ruby/gems/2.1.0/gems/pact-support-0.4.0/lib/pact/matchers/matchers.rb:20: warning: already initialized constant Pact::Matchers::DEFAULT_OPTIONS
/usr/local/opt/rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/pact-support-0.4.0/lib/pact/matchers/matchers.rb:20: warning: previous definition of DEFAULT_OPTIONS was here
/usr/local/Cellar/rbenv/0.4.0/versions/2.1.2/lib/ruby/gems/2.1.0/gems/pact-support-0.4.0/lib/pact/matchers/matchers.rb:21: warning: already initialized constant Pact::Matchers::NO_DIFF
/usr/local/opt/rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/pact-support-0.4.0/lib/pact/matchers/matchers.rb:21: warning: previous definition of NO_DIFF was here
/usr/local/opt/rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/pact-support-0.4.0/lib/pact/configuration.rb:13: warning: already initialized constant Pact::Configuration::DIFF_FORMATTERS
/usr/local/Cellar/rbenv/0.4.0/versions/2.1.2/lib/ruby/gems/2.1.0/gems/pact-support-0.4.0/lib/pact/configuration.rb:13: warning: previous definition of DIFF_FORMATTERS was here
/usr/local/opt/rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/pact-support-0.4.0/lib/pact/configuration.rb:26: warning: already initialized constant Pact::Configuration::DIFF_FORMATTER_REGISTRATIONS
/usr/local/Cellar/rbenv/0.4.0/versions/2.1.2/lib/ruby/gems/2.1.0/gems/pact-support-0.4.0/lib/pact/configuration.rb:26: warning: previous definition of DIFF_FORMATTER_REGISTRATIONS was here
/usr/local/opt/rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/pact-support-0.4.0/lib/pact/configuration.rb:31: warning: already initialized constant Pact::Configuration::DIFFERS
/usr/local/Cellar/rbenv/0.4.0/versions/2.1.2/lib/ruby/gems/2.1.0/gems/pact-support-0.4.0/lib/pact/configuration.rb:31: warning: previous definition of DIFFERS was here
/usr/local/opt/rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/pact-support-0.4.0/lib/pact/configuration.rb:39: warning: already initialized constant Pact::Configuration::DEFAULT_DIFFER
/usr/local/Cellar/rbenv/0.4.0/versions/2.1.2/lib/ruby/gems/2.1.0/gems/pact-support-0.4.0/lib/pact/configuration.rb:39: warning: previous definition of DEFAULT_DIFFER was here
```
