### PR TITLE
Apply reification to ArrayLike flexible matcher.

### DIFF
--- a/lib/pact/reification.rb
+++ b/lib/pact/reification.rb
@@ -7,7 +7,7 @@ module Pact
 
     def self.from_term(term)
       case term
-      when Pact::Term, Regexp, Pact::SomethingLike
+      when Pact::Term, Regexp, Pact::SomethingLike, Pact::ArrayLike
       term.generate
       when Hash
         term.inject({}) do |mem, (key,term)|

--- a/spec/lib/pact/reification_spec.rb
+++ b/spec/lib/pact/reification_spec.rb
@@ -63,6 +63,18 @@ module Pact
 
     end
 
+    context "when ArrayLike" do
+
+      let(:request) { Pact::ArrayLike.new({a: 'String'}, {min: 3})}
+
+      subject { Reification.from_term(request)}
+
+      it "returns the contents of the ArrayLike" do
+        expect(subject).to eq([{a: 'String'}, {a: 'String'}, {a: 'String'}])
+      end
+
+    end
+
     context "when Query" do
 
       let(:query) { QueryString.new(Pact::Term.new(generate: "param=thing", matcher: /param=.*/)) }


### PR DESCRIPTION
See https://github.com/bethesque/pact-mock_service/issues/26, we noticed when creating the Array based flexible matchers in the JS DSL, that whilst the provider verification worked, the mock service responded with serialised Ruby, rather than the expected response. e.g.

```
{ items: Object({ json_class: 'Pact::ArrayLike', contents: Object({ a: 'String' }), min: 3 }) }) 
```

It seemed the `ArrayLike` class wasn't being properly reified. The response now looks something like:

```
[{a: 'String'}, {a: 'String'}, {a: 'String'}]
```

Additionally, we'll create a test case in the Mock Service project for this.