### PR TITLE
Fixed min = 0 issue with array reification

### DIFF
--- a/lib/pact/array_like.rb
+++ b/lib/pact/array_like.rb
@@ -41,7 +41,9 @@ module Pact
     end
 
     def generate
-      min.times.collect{ Pact::Reification.from_term contents }
+      n = min
+      n = 1 if n == 0
+      n.times.collect{ Pact::Reification.from_term contents }
     end
   end
 end

--- a/spec/lib/pact/array_like_spec.rb
+++ b/spec/lib/pact/array_like_spec.rb
@@ -26,11 +26,22 @@ module Pact
       end
     end
 
-    subject { ArrayLike.new({name: Pact::Term.new(generate: 'Fred', matcher: /F/)}, {min: 2}) }
 
     describe "#generate" do
-      it "creates an array with the reified example" do
-        expect(subject.generate).to eq [{name: 'Fred'},{name: 'Fred'}]
+      context "when min > 0" do
+        subject { ArrayLike.new({name: Pact::Term.new(generate: 'Fred', matcher: /F/)}, {min: 2}) }
+
+        it "creates an array with 'min' reified example members" do
+          expect(subject.generate).to eq [{name: 'Fred'},{name: 'Fred'}]
+        end
+      end
+
+      context "when min == 0" do
+        subject { ArrayLike.new({name: Pact::Term.new(generate: 'Fred', matcher: /F/)}, {min: 0}) }
+
+        it "creates an array with 1 reified example" do
+          expect(subject.generate).to eq [{name: 'Fred'}]
+        end
       end
     end
   end


### PR DESCRIPTION
What we've observed in testing the ArrayLike functionality, is that if `min` is set to `0`, then two things occur:

1. No sample JSON is left in place in the Pact file for that particular element (and if that element is the root, you get a rather boring Pact file)
2. When validating on the Provider side, using the proxy service at least, it cannot validate the zero or more case. So if there is an element, it fails. Put another way, it validates that there _is_ zero, not _at least_ zero elements.

This PR ensures during reification that at least one sample is always present in the document, even for the `min = 0` case. In our integration testing, this appears to now allow a "zero or more" rule whilst still enforcing existing rules around matching. 

I'm happy to provide examples if required to help articulate the issue further.
