### PR TITLE
Nested `QueryHash`

### DIFF
--- a/lib/pact/consumer_contract/query_hash.rb
+++ b/lib/pact/consumer_contract/query_hash.rb
@@ -13,10 +13,6 @@ module Pact
       @hash = query.nil? ? query : convert_to_hash_of_arrays(query)
     end
 
-    def convert_to_hash_of_arrays query
-      symbolize_keys(query).each_with_object({}) {|(k,v), hash| hash[k] = [*v] }
-    end
-
     def as_json opts = {}
       @hash
     end
@@ -51,5 +47,18 @@ module Pact
       @hash && @hash.empty?
     end
 
+    private
+
+    def convert_to_hash_of_arrays(query)
+      query.each_with_object({}) {|(k, v), hash| insert(hash, k, v) }
+    end
+
+    def insert(hash, k, v)
+      if Hash === v
+        v.each {|k2, v2| insert(hash, :"#{k}[#{k2}]", v2) }
+      else
+        hash[k.to_sym] = [*v]
+      end
+    end
   end
 end

--- a/lib/pact/consumer_contract/query_hash.rb
+++ b/lib/pact/consumer_contract/query_hash.rb
@@ -9,23 +9,23 @@ module Pact
     include Pact::Matchers
     include SymbolizeKeys
 
-    def initialize query
+    def initialize(query)
       @hash = query.nil? ? query : convert_to_hash_of_arrays(query)
     end
 
-    def as_json opts = {}
+    def as_json(opts = {})
       @hash
     end
 
-    def to_json opts = {}
+    def to_json(opts = {})
       as_json(opts).to_json(opts)
     end
 
-    def eql? other
+    def eql?(other)
       self == other
     end
 
-    def == other
+    def ==(other)
       QueryHash === other && other.query == query
     end
 

--- a/spec/lib/pact/consumer_contract/query_hash_spec.rb
+++ b/spec/lib/pact/consumer_contract/query_hash_spec.rb
@@ -34,6 +34,45 @@ module Pact
           expect(subject.difference(other)).to_not be_empty
         end
       end
+
+      context "with nested query" do
+        let(:query) { { param: { a: { aa: '11', bb: '22' }, b: '2' } } }
+
+        context "when the other is same" do
+          let(:other) { QueryString.new('param[b]=2&param[a][aa]=11&param[a][bb]=22') }
+
+          it 'returns an empty diff' do
+            expect(subject.difference(other)).to be_empty
+          end
+        end
+
+        context "when the other has extra param" do
+          let(:other) { QueryString.new('param[b]=2&param[c]=1') }
+
+          it 'returns the diff' do
+            expect(subject.difference(other)).not_to be_empty
+            expect(subject.difference(other).keys).to contain_exactly(:"param[a][aa]", :"param[a][bb]", :"param[c]")
+          end
+        end
+
+        context "when the other has different value with value difference" do
+          let(:other) { QueryString.new('param[b]=2&param[a][aa]=00&param[a][bb]=22') }
+
+          it 'returns the diff' do
+            expect(subject.difference(other)).not_to be_empty
+            expect(subject.difference(other).keys).to contain_exactly(:"param[a][aa]")
+          end
+        end
+
+        context "when the other has different value without structural difference" do
+          let(:other) { QueryString.new('param[b]=2&param[a]=11') }
+
+          it 'returns the diff' do
+            expect(subject.difference(other)).not_to be_empty
+            expect(subject.difference(other).keys).to contain_exactly(:"param[a]", :"param[a][aa]", :"param[a][bb]")
+          end
+        end
+      end
     end
 
     describe "#as_json" do

--- a/spec/lib/pact/consumer_contract/request_spec.rb
+++ b/spec/lib/pact/consumer_contract/request_spec.rb
@@ -331,6 +331,15 @@ module Pact
           end
         end
 
+        context 'when the queries are defined by nested hashes' do
+          let(:expected_query) { { params: 'hello', nested: { a: { aa: '11', bb: '22' }, b: '2' }, params3: 'small' } }
+          let(:actual_query) { 'params3=small&nested[a][aa]=11&nested[a][bb]=22&nested[b]=2&params=hello'  }
+
+          it "does match" do
+            expect(subject.matches? actual_request).to be true
+          end
+        end
+
         context 'when the queries are defined by hashes, order does not matter but content does' do
           let(:expected_query) { { params: 'hello', params2: 'world', params3: 'small' } }
           let(:actual_query) { 'params3=big&params2=world&params=hello' }
@@ -358,11 +367,29 @@ module Pact
           end
         end
 
+        context 'when the queries are defined by nested hashes holding Pact Terms, order does not matter but content does' do
+          let(:expected_query) { { params: { a: 'hello', b: Term.new(generate: 'world', matcher: /w\w+/) } } }
+          let(:actual_query) { 'params[a]=hello&params[b]=wroom'}
+
+          it "does match" do
+            expect(subject.matches? actual_request).to be true
+          end
+        end
+
         context 'when the queries are defined by hashes holding Pact Terms and the regex does not match' do
           let(:expected_query) { { params: 'hello', params2: Term.new(generate: 'world', matcher: /w\w+/), params3: 'small' } }
           let(:actual_query) { 'params3=small&params=hello&params2=bonjour'}
 
           it "does not match" do
+            expect(subject.matches? actual_request).to be false
+          end
+        end
+
+        context 'when the queries are defined by nested hashes holding Pact Terms and the regex does not match' do
+          let(:expected_query) { { params: { a: 'hello', b: Term.new(generate: 'world', matcher: /w\w+/) } } }
+          let(:actual_query) { 'params[a]=hello&params[b]=bonjour'}
+
+          it "does match" do
             expect(subject.matches? actual_request).to be false
           end
         end


### PR DESCRIPTION
When I wrote pact expectation with nested hash query, it did not work as I expected. `Pact::QueryHash` seems not to support nested hash query.

I tried with `Rack::Utils.parse_nested_query` but it breaks current behavior with "double param": `param=a&param=b` should be parsed as `{ param: ['a', 'b'] }` while `Rack::Utils.parse_nested_query` parses as `{ param: 'b' }`.
So I simply treat keys of nested hash with `CGI.parse` manner. It works and seems not to break current behavior.

I tried this patch with my project above and it works.