### PR TITLE
`raise_error` should be with specific error

### DIFF
--- a/spec/support/shared_examples_for_request.rb
+++ b/spec/support/shared_examples_for_request.rb
@@ -115,12 +115,12 @@ shared_examples "a request" do
 
     it "blows up if method is absent" do
       raw_request.delete 'method'
-      expect { described_class.from_hash(raw_request) }.to raise_error
+      expect { described_class.from_hash(raw_request) }.to raise_error(KeyError)
     end
 
     it "blows up if path is absent" do
       raw_request.delete 'path'
-      expect { described_class.from_hash(raw_request) }.to raise_error
+      expect { described_class.from_hash(raw_request) }.to raise_error(KeyError)
     end
 
     it "does not blow up if body is missing" do


### PR DESCRIPTION
RSpec says...

```
WARNING: Using the `raise_error` matcher without providing a specific
error or message risks false positives, since `raise_error` will match
when Ruby raises a `NoMethodError`, `NameError` or `ArgumentError`,
potentially allowing the expectation to pass without even executing
the method you are intending to call. Actual error raised was
specific error class or message. This message can be supressed by
setting: `RSpec::Expectations.configuration.warn_about_potential_false_positives = false`.
```

Since the error focused in this example is raised by `Hash#fetch`, specifying `KeyError` looks reasonable here for me.