### PR TITLE
[Proposal] Drop supporting ruby1.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: ruby
 rvm:
-  - 1.9.3
   - 2.0.0
-  - 2.1.1
+  - 2.1.8
+  - 2.2.4
+  - 2.3.0
   - jruby-19mode
   - jruby-1.7.11
   - jruby-1.7.12


### PR DESCRIPTION
ref: https://travis-ci.org/bethesque/pact-support/jobs/115061042

The tins gem which pact-support depends does not support ruby1.9 any more. https://github.com/flori/tins/commit/9ebb625d8a987bd54526006441ff97bc14c30e53

You can also pin tins gem version under 1.7.0, but in my humble option, users of pact-support gem will be more happy with new rubies and new gems than old ones.