### PR TITLE
Escape query string components

### DIFF
--- a/lib/pact/reification.rb
+++ b/lib/pact/reification.rb
@@ -25,14 +25,18 @@ module Pact
           if v.nil?
             k
           elsif v.is_a?(Array) #For cases where there are multiple instance of the same parameter
-            v.map { |x| "#{k}=#{from_term(x)}"}.join('&')
+            v.map { |x| "#{k}=#{escape(from_term(x))}"}.join('&')
           else
-            "#{k}=#{from_term(v)}"
+            "#{k}=#{escape(from_term(v))}"
           end
         }.join('&')
       else
         term
       end
+    end
+
+    def self.escape(str)
+      URI.encode_www_form_component(str)
     end
   end
 end

--- a/lib/pact/reification.rb
+++ b/lib/pact/reification.rb
@@ -20,7 +20,7 @@ module Pact
         from_term(term.to_hash)
       when Pact::QueryString
         from_term(term.query)
-        when Pact::QueryHash
+      when Pact::QueryHash
         term.query.map { |k, v|
           if v.nil?
             k

--- a/spec/lib/pact/reification_spec.rb
+++ b/spec/lib/pact/reification_spec.rb
@@ -98,6 +98,17 @@ module Pact
       end
     end
 
+    context "when Hash Query with UTF-8 string" do
+
+      subject { Reification.from_term(query)}
+
+      let(:query) { QueryHash.new( {param: 'ILove', extra: '寿司'})}
+
+      it "returns the hash with escaping UTF-8 string" do
+        expect(subject).to eq("param=ILove&extra=%E5%AF%BF%E5%8F%B8")
+      end
+    end
+
     context "when Hash Query with embeded terms" do
 
       subject { Reification.from_term(query)}


### PR DESCRIPTION
`Pact::Reification.from_term` does nearly the same thing as
`Rack::Utils.build_query` does with extracting Pact's terms.
We should escape query values to follow URI spec.

ref: https://github.com/rack/rack/blob/1.6.4/lib/rack/utils.rb#L180

Without escaping, Pact generates pact file without escaping query and it
causes `URI::InvalidURIError` with "URI must be ascii only" message when
replay the request in `pact:verify`.

P.S. "寿司" means :sushi: in Japanese :yum: 