### PR TITLE
Supporting nested Pact::SomethingLike reification

### DIFF
--- a/lib/pact/reification.rb
+++ b/lib/pact/reification.rb
@@ -8,7 +8,7 @@ module Pact
     def self.from_term(term)
       case term
       when Pact::Term, Regexp, Pact::SomethingLike, Pact::ArrayLike
-        term.generate
+        from_term(term.generate)
       when Hash
         term.inject({}) do |mem, (key,term)|
           mem[key] = from_term(term)

--- a/spec/lib/pact/reification_spec.rb
+++ b/spec/lib/pact/reification_spec.rb
@@ -63,6 +63,27 @@ module Pact
 
     end
 
+    context "when nested SomethingLike" do
+
+      let(:request) {
+        Pact::SomethingLike.new(
+          {
+            a: 'String',
+            b: Pact::SomethingLike.new(
+              c: 'NestedString'
+            )
+          }
+        )
+      }
+
+      subject { Reification.from_term(request)}
+
+      it "returns the contents of the SomethingLike" do
+        expect(subject).to eq({a: 'String', b: { c: 'NestedString' }})
+      end
+
+    end
+
     context "when ArrayLike" do
 
       let(:request) { Pact::ArrayLike.new({a: 'String'}, {min: 3})}


### PR DESCRIPTION
Hello.

I had added the case of nested `Pact::SomethingLike` when reification.
Please confirm. Thanks.

## Before

```ruby
[13] pry(main)> request = Pact::SomethingLike.new(
[13] pry(main)*   {
[13] pry(main)*     a: 'String',
[13] pry(main)*     b: Pact::SomethingLike.new(
[13] pry(main)*       c: 'NestedString'
[13] pry(main)*     )
[13] pry(main)*   }
[13] pry(main)* )
=> #<Pact::SomethingLike:0x007f90139a1460 @contents={:a=>"String", :b=>#<Pact::SomethingLike:0x007f90139a14b0 @contents={:c=>"NestedString"}>}>
[14] pry(main)> Pact::Reification.from_term(request)
=> {:a=>"String", :b=>#<Pact::SomethingLike:0x007f90139a14b0 @contents={:c=>"NestedString"}>}
```

## After

```ruby
[8] pry(main)> request = Pact::SomethingLike.new(
[8] pry(main)*   {
[8] pry(main)*     a: 'String',
[8] pry(main)*     b: Pact::SomethingLike.new(
[8] pry(main)*       c: 'NestedString'
[8] pry(main)*     )
[8] pry(main)*   }
[8] pry(main)* )
=> #<Pact::SomethingLike:0x007f8008b75518 @contents={:a=>"String", :b=>#<Pact::SomethingLike:0x007f8008b75568 @contents={:c=>"NestedString"}>}>
[9] pry(main)> Pact::Reification.from_term(request)
=> {:a=>"String", :b=>{:c=>"NestedString"}}
```