### PR TITLE
Retry reading pact file

### DIFF
--- a/pact-support.gemspec
+++ b/pact-support.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'thor'
 
   gem.add_development_dependency 'rake', '~> 10.0.3'
-  gem.add_development_dependency 'webmock', '~> 1.18.0'
+  gem.add_development_dependency 'webmock', '~> 2.0.0'
   gem.add_development_dependency 'pry'
   gem.add_development_dependency 'fakefs', '~> 0.4'
   gem.add_development_dependency 'hashie', '~> 2.0'

--- a/spec/lib/pact/consumer_contract/pact_file_spec.rb
+++ b/spec/lib/pact/consumer_contract/pact_file_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 require 'pact/consumer_contract/pact_file'
+require 'base64' # XXX: https://github.com/bblimke/webmock/pull/611
 
 module Pact
   describe PactFile do
@@ -7,8 +8,11 @@ module Pact
       let(:uri_without_userinfo) { 'http://pactbroker.com'}
       let(:pact_content) { 'api contract'}
       context 'without basic authentication' do
+        before do
+          stub_request(:get, uri_without_userinfo).to_return(body: pact_content)
+        end
+
         it 'should open uri to get pact file content' do
-          expect(PactFile).to receive(:open).with(uri_without_userinfo, {}).and_return(pact_content)
           expect(PactFile.render_pact(uri_without_userinfo, {})).to eq(pact_content)
         end
       end
@@ -19,25 +23,26 @@ module Pact
         let(:options) do
           { username: username, password: password }
         end
+        before do
+          stub_request(:get, uri_without_userinfo).with(basic_auth: [username, password]).to_return(body: pact_content)
+        end
+
         context 'when userinfo is specified in the option' do
           it 'should open uri to get pact file content with userinfo in the options' do
-            expect(PactFile).to receive(:open).with(uri_without_userinfo, {http_basic_authentication:[username, password]})
-                                .and_return(pact_content)
             expect(PactFile.render_pact(uri_without_userinfo, options)).to eq(pact_content)
           end
+
           let(:uri_with_userinfo) { 'http://dummyuser:dummyps@pactbroker.com'}
+
           it 'should use userinfo in options which overwrites userinfo in url' do
-            expect(PactFile).to receive(:open).with(uri_without_userinfo, {http_basic_authentication:[username, password]})
-                                .and_return(pact_content)
             expect(PactFile.render_pact(uri_with_userinfo, options)).to eq(pact_content)
           end
         end
 
         context 'when user info is specified in url' do
           let(:uri_with_userinfo) { "http://#{username}:#{password}@pactbroker.com"}
+
           it 'should open uri to get pact file content with userinfo in the uri' do
-            expect(PactFile).to receive(:open).with(uri_without_userinfo, {http_basic_authentication:[username, password]})
-                                .and_return(pact_content)
             expect(PactFile.render_pact(uri_with_userinfo, {})).to eq(pact_content)
           end
         end


### PR DESCRIPTION
We run pact verification with pact_broker in CI job. Sometimes, pact_broker responds server error and that causes our CI failed. This is annoying for me. I think fetching pact file can be retryable. How about this change?