### PR TITLE
Enable interactions to validate themselves

### DIFF
--- a/lib/pact/consumer_contract/interaction.rb
+++ b/lib/pact/consumer_contract/interaction.rb
@@ -3,6 +3,7 @@ require 'pact/consumer_contract/response'
 require 'pact/symbolize_keys'
 require 'pact/shared/active_support_support'
 require 'pact/matching_rules'
+require 'pact/errors'
 
 module Pact
    class Interaction
@@ -33,6 +34,10 @@ module Pact
           request: request.to_hash,
           response: response.to_hash
         }
+      end
+
+      def validate!
+        raise Pact::InvalidInteractionError.new(self) unless description && request && response
       end
 
       def matches_criteria? criteria

--- a/lib/pact/errors.rb
+++ b/lib/pact/errors.rb
@@ -1,0 +1,21 @@
+module Pact
+  class Error < ::StandardError
+  end
+
+  # Raised when the interaction is not defined correctly
+  class InvalidInteractionError < Error
+    def initialize(interaction)
+      super(build_message(interaction))
+    end
+
+    private
+
+    def build_message(interaction)
+      missing_attributes = []
+      missing_attributes << :description unless interaction.description
+      missing_attributes << :request unless interaction.request
+      missing_attributes << :response unless interaction.response
+      "Missing attributes: #{missing_attributes}"
+    end
+  end
+end

--- a/spec/lib/pact/consumer_contract/interaction_spec.rb
+++ b/spec/lib/pact/consumer_contract/interaction_spec.rb
@@ -118,7 +118,27 @@ module Pact
             expect(subject).to be false
           end
         end
+      end
 
+      describe "#validate!" do
+        let(:interaction) { InteractionFactory.create }
+
+        context "when it lacks necessary data" do
+          before { interaction.description = nil }
+
+          it "raises Pact::InvalidInteractionError" do
+            expect { interaction.validate! }.to(raise_error(Pact::InvalidInteractionError) do |e|
+              expect(e.message).to include("description")
+              expect(e.message).not_to include("request")
+            end)
+          end
+        end
+
+        context "when it has all necessary data" do
+          it "does not raise any errors" do
+            expect { interaction.validate! }.not_to raise_error
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
To ensure they have all necessary data. The lack of data can cause
errors in pact verification.

This is a follow up PR for https://github.com/realestate-com-au/pact/pull/122.