### PR TITLE
move awesome_print dependency to development

### DIFF
--- a/lib/pact/matchers/matchers.rb
+++ b/lib/pact/matchers/matchers.rb
@@ -1,4 +1,3 @@
-require 'awesome_print'
 require 'pact/term'
 require 'pact/something_like'
 require 'pact/shared/null_expectation'

--- a/pact-support.gemspec
+++ b/pact-support.gemspec
@@ -22,12 +22,12 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'randexp', '~> 0.1.7'
   gem.add_runtime_dependency 'rspec', '>=2.14'
   gem.add_runtime_dependency 'rack-test', '~> 0.6.2'
-  gem.add_runtime_dependency 'awesome_print', '~> 1.1'
   gem.add_runtime_dependency 'json'
   gem.add_runtime_dependency 'term-ansicolor', '~> 1.0'
   gem.add_runtime_dependency 'find_a_port', '~> 1.0.1'
   gem.add_runtime_dependency 'thor'
 
+  gem.add_development_dependency 'awesome_print', '~> 1.1'
   gem.add_development_dependency 'rake', '~> 10.0.3'
   gem.add_development_dependency 'webmock', '~> 2.0.0'
   gem.add_development_dependency 'pry'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,4 @@
+require 'awesome_print'
 require 'rspec'
 require 'fakefs/spec_helpers'
 require 'rspec'


### PR DESCRIPTION
This gem shouldn't be included as a production dependency.