### PR TITLE
Added colon support to matching rules path.

### DIFF
--- a/lib/pact/matching_rules/jsonpath.rb
+++ b/lib/pact/matching_rules/jsonpath.rb
@@ -19,7 +19,7 @@ module Pact
             @path << token
           elsif token = scanner.scan(/@/)
             @path << token
-          elsif token = scanner.scan(/[a-zA-Z0-9_-]+/)
+          elsif token = scanner.scan(/[:a-zA-Z0-9_-]+/)
             @path << "['#{token}']"
           elsif token = scanner.scan(/'(.*?)'/)
             @path << "[#{token}]"
@@ -57,4 +57,3 @@ module Pact
     end
   end
 end
-


### PR DESCRIPTION
We are using a HAL api that uses colon for namespacing, here is an example:

```
{
    "doc:book": "value"
}
```

Matching rules are currently not applied properly because of the colon character, making us unable to verify mocks.

```
"matchingRules": {
    "$.doc:book": {
```

I've added this simple fix, it'd be great to get this merged in asap as I have to try to bring this until pact-js.

Note: the path with colon are parsed correctly if they are in a each like matchers.

Food for thoughts: other libraries are using a dot for namespacing, others are using a hash or a dollar sign for json property names (like json schema), which would also break the string scanner regexes.

Another "path format" would need to be supported.

I didn't write a test as this class is apparently not tested.
I was also unable to make the tests pass on master.

