### PR TITLE
Fix/explicit require cgi

### DIFF
--- a/lib/pact/consumer_contract/query_hash.rb
+++ b/lib/pact/consumer_contract/query_hash.rb
@@ -1,3 +1,4 @@
+require 'cgi'
 require 'pact/shared/active_support_support'
 require 'pact/matchers'
 require 'pact/symbolize_keys'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,11 +1,8 @@
-require 'rspec'
 require 'fakefs/spec_helpers'
-require 'rspec'
 require 'pact/support'
 require 'webmock/rspec'
 require 'support/factories'
 require 'support/spec_support'
-
 
 WebMock.disable_net_connect!(allow_localhost: true)
 


### PR DESCRIPTION
## Why
Running `bundle exec rake spec` fails due to:

```
Failure/Error: diff(query, symbolize_keys(CGI::parse(other.query)), allow_unexpected_keys: false)
     
NoMethodError:
  undefined method `parse' for CGI:Class
```

## How
This is an existing issue on master and I can reproduce it locally. Oddly enough `bundle exec rspec <filename>` does not exhibit this issue. It seems like Ruby resolves `CGI` class definition to `cgi/util.rb` and ignores `cgi/core.rb` >.<

```
> bundle exec rspec
pry(#<RSpec::ExampleGroups::PactQueryHash::Difference::WhenTheOtherIsTheSame>)> show-source CGI

From: ~/.rubies/ruby-2.3.3/lib/ruby/2.3.0/cgi/core.rb @ line 6:

> bundle exec rake
pry(#<RSpec::ExampleGroups::PactQueryHash::Difference::WhenTheOtherIsTheSame>)> show-source CGI

From: /Users/tanle/.rubies/ruby-2.3.3/lib/ruby/2.3.0/cgi/util.rb @ line 2:
```

## What have been done
Explicitly require CGI class and ensure `core.rb` and `util.rb` are loaded in the right order.

This should fix #27. 