### PR TITLE
fix: relax json pin restriction to minor, not patch revision

### DIFF
--- a/pact-support.gemspec
+++ b/pact-support.gemspec
@@ -24,7 +24,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "diff-lcs", "~> 1.6"
   spec.add_runtime_dependency "expgen", "~> 0.1"
   spec.add_runtime_dependency 'string_pattern', '~> 2.0'
-  spec.add_runtime_dependency 'json', '~> 2.12.2'
   spec.add_runtime_dependency 'jsonpath', '~> 1.0'
   spec.add_runtime_dependency 'logger', '< 2.0'
   spec.add_development_dependency "stringio", "~> 3"


### PR DESCRIPTION
Hey @impurist,

This following commit pins json to a json's patch version, could we relax it to patch so that we can use the latest json gem in the pact-docker-cli

https://github.com/pact-foundation/pact-support/commit/6da53f538c8fce71fe8c1f22b2cdbaf6dd82c13d

pact-docker-cli fails to update, as it requires `-> 2.18`

https://github.com/pact-foundation/pact-docker-cli/actions/runs/20855919023/job/59922394460

Thank you!

PS. the restriction is too strict for pact-standalone, which currently uses standard gems from ruby 3.3.9. of which json is 2.7.2, that can be resolved, by using native extensions which I've recently built for all platforms (windows support is new), which is why previously we had to pin to std gems to avoid building native extensions